### PR TITLE
Use cameras only if they exist in the robot configuration file.

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -127,12 +127,16 @@ public class Robot extends TimedRobot {
         senseConf.getInt("numSensors"));
 
     // Camera Code
-    UsbCamera camera0 = CameraServer.getInstance().startAutomaticCapture(0);
-    UsbCamera camera1 = CameraServer.getInstance().startAutomaticCapture(1);
-    camera0.setResolution(320, 240);
-    camera0.setFPS(10);
-    camera1.setResolution(320, 240);
-    camera1.setFPS(10);
+    if (conf.hasPath("cameras")) {
+      Config cameraConf = conf.getConfig("cameras");
+
+      UsbCamera camera0 = CameraServer.getInstance().startAutomaticCapture(cameraConf.getInt("camera0"));
+      UsbCamera camera1 = CameraServer.getInstance().startAutomaticCapture(cameraConf.getInt("camera1"));
+      camera0.setResolution(320, 240);
+      camera0.setFPS(10);
+      camera1.setResolution(320, 240);
+      camera1.setFPS(10);
+    }
 
     if (conf.hasPath("sensors.lineFollowSensor")) {
       lineFollowerSensorArray = new LineFollowerSensorArray(sunfounderbus, senseConf.getInt("detectionThreshold"),


### PR DESCRIPTION
Could somebody please review and test this change, and then merge it to master.

Owen and I were using it on Monday to eliminate warning messages on the practice robot that doesn't have any cameras.  It should work fine on the real/practice robot, but we need to add the appropriate items to the configuration file (and test it at least once).  Hopefully, I should be there Wednesday evening to do that, but if not, could somebody else configure the robot and test the change for me.
