### PR TITLE
adding flag to enable on-off tags in the formatter

### DIFF
--- a/frc4905.eclipseformat.xml
+++ b/frc4905.eclipseformat.xml
@@ -72,7 +72,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="80"/>
-        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_never"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line" value="one_line_never"/>


### PR DESCRIPTION
Requested by @wpd ... This flag lets you temporarily disable formatting (spotless) in a file by blocking off the code:

```
// @formatter:off
System.out.println("This will NOT be formatted");
Arrays.asList(
    "one",
    "two");
// @formatter:on
```

Use with care!