### PR TITLE
fix the stupid java warning wrt creating a new templated class (that …

### DIFF
--- a/src/main/java/frc/robot/closedloopcontrollers/pidcontrollers/DrivetrainFrontUltrasonicPIDController.java
+++ b/src/main/java/frc/robot/closedloopcontrollers/pidcontrollers/DrivetrainFrontUltrasonicPIDController.java
@@ -41,8 +41,8 @@ public class DrivetrainFrontUltrasonicPIDController extends PIDControllerBase {
      */
     @Override
     public void pidWrite(double output) {
-      Trace.getInstance().addTrace(true, "FrontUltrasonicDrivetrain", new TracePair("Output", output),
-          new TracePair("Setpoint", pidMultiton.getSetpoint()), new TracePair("DistanceInches", ultrasonic.pidGet()));
+      Trace.getInstance().addTrace(true, "FrontUltrasonicDrivetrain", new TracePair<>("Output", output),
+          new TracePair<>("Setpoint", pidMultiton.getSetpoint()), new TracePair("DistanceInches", ultrasonic.pidGet()));
 
       Robot.gyroCorrectMove.moveUsingGyro(output, 0, false, false);
     }

--- a/src/main/java/frc/robot/closedloopcontrollers/pidcontrollers/ExtendableArmPIDController.java
+++ b/src/main/java/frc/robot/closedloopcontrollers/pidcontrollers/ExtendableArmPIDController.java
@@ -50,20 +50,7 @@ public class ExtendableArmPIDController extends PIDControllerBase {
 
     @Override
     public void pidWrite(double output) {
-      /*
-       * Trace.getInstance().addTrace(true, "ExtensionPID", new TracePair("Output",
-       * output), new TracePair("SetpointTicks", pidMultiton.getSetpoint()), new
-       * TracePair("SetpointInches", pidMultiton.getSetpoint() *
-       * Robot.EXTENSIONINCHESPERTICK), new TracePair("ExtensionTicks",
-       * armPIDSource.pidGet()), new TracePair("ExtensionInches",
-       * armPIDSource.pidGet() * Robot.EXTENSIONINCHESPERTICK));
-       */
-      // try {
       MoveArmAndWristSafely.setPidExtensionPower(output);
-      // } catch (ArmOutOfBoundsException e) {
-      // System.out.println(e.getMessage());
-      // container.disable();
-      // }
     }
   }
 

--- a/src/main/java/frc/robot/closedloopcontrollers/pidcontrollers/PIDBase4905.java
+++ b/src/main/java/frc/robot/closedloopcontrollers/pidcontrollers/PIDBase4905.java
@@ -324,10 +324,10 @@ public class PIDBase4905 extends SendableBase implements PIDInterface, PIDOutput
       } finally {
         m_pidWriteMutex.unlock();
       }
-      Trace.getInstance().addTrace(true, m_pidName, new TracePair("TotalError", m_totalError),
-          new TracePair("PError", m_pError), new TracePair("IError", m_iError), new TracePair("DError", m_dError),
-          new TracePair("FeedForward", m_feedForward), new TracePair("AccumError", m_accumError),
-          new TracePair("Input", input), new TracePair("Setpoint", m_setpoint));
+      Trace.getInstance().addTrace(true, m_pidName, new TracePair<>("TotalError", m_totalError),
+          new TracePair<>("PError", m_pError), new TracePair("IError", m_iError), new TracePair("DError", m_dError),
+          new TracePair<>("FeedForward", m_feedForward), new TracePair("AccumError", m_accumError),
+          new TracePair<>("Input", input), new TracePair("Setpoint", m_setpoint));
     }
   }
 

--- a/src/main/java/frc/robot/closedloopcontrollers/pidcontrollers/ShoulderPIDController.java
+++ b/src/main/java/frc/robot/closedloopcontrollers/pidcontrollers/ShoulderPIDController.java
@@ -42,20 +42,7 @@ public class ShoulderPIDController extends PIDControllerBase {
 
     @Override
     public void pidWrite(double output) {
-      /*
-       * Trace.getInstance().addTrace(true, "ShoulderPID", new TracePair("Output",
-       * output * 10000), new TracePair("SetpointTicks", pidMultiton.getSetpoint()),
-       * new TracePair("SetpointDegrees", pidMultiton.getSetpoint() *
-       * Robot.SHOULDERDEGREESPERTICK), new TracePair("AngleTicks",
-       * shoulderPIDSrc.pidGet()), new TracePair("AngleDegrees",
-       * shoulderPIDSrc.pidGet() * Robot.SHOULDERDEGREESPERTICK));
-       */
-      // try {
       MoveArmAndWristSafely.setPidShoulderPower(output);
-      // } catch (ArmOutOfBoundsException e) {
-      // System.out.println(e.getMessage());
-      // container.disable();
-      // }
     }
   }
 

--- a/src/main/java/frc/robot/closedloopcontrollers/pidcontrollers/WristPIDController.java
+++ b/src/main/java/frc/robot/closedloopcontrollers/pidcontrollers/WristPIDController.java
@@ -52,20 +52,7 @@ public class WristPIDController extends PIDControllerBase {
     @Override
     public void pidWrite(double output) {
       ArmPosition currentArmPosition = Robot.getCurrentArmPosition();
-      /*
-       * Trace.getInstance().addTrace(true, "WristPID", new TracePair("Output",
-       * output), new TracePair("SetpointTicks", pidMultiton.getSetpoint()), new
-       * TracePair("SetpointDegrees", pidMultiton.getSetpoint() *
-       * Robot.WRISTDEGREESPERTICK), new TracePair("TicksAngle",
-       * wristPIDSource.pidGet()), new TracePair("DegreeAngle",
-       * currentArmPosition.getWristAngle()));
-       */
-      // try {
       MoveArmAndWristSafely.setPidWristPower(output);
-      // } catch (ArmOutOfBoundsException e) {
-      // System.out.println(e.getMessage());
-      // container.disable();
-      // }
     }
   }
 

--- a/src/main/java/frc/robot/sensors/NavXGyroSensor.java
+++ b/src/main/java/frc/robot/sensors/NavXGyroSensor.java
@@ -104,8 +104,8 @@ public class NavXGyroSensor extends SensorBase implements PIDSource {
       SmartDashboard.putNumber("Get Robot Angle", correctedAngle);
     }
     robotAngleCount++;
-    Trace.getInstance().addTrace(true, "Gyro", new TracePair("Raw Angle", gyro.getAngle()),
-        new TracePair("Corrected Angle", correctedAngle));
+    Trace.getInstance().addTrace(false, "Gyro", new TracePair<>("Raw Angle", gyro.getAngle()),
+        new TracePair<>("Corrected Angle", correctedAngle));
 
     return correctedAngle;
   }

--- a/src/main/java/frc/robot/sensors/linefollowersensor/LineFollowerSensorBase.java
+++ b/src/main/java/frc/robot/sensors/linefollowersensor/LineFollowerSensorBase.java
@@ -57,13 +57,13 @@ public abstract class LineFollowerSensorBase {
         SmartDashboard.putNumber("Distance From Center", currentDistanceFromCenter);
         SmartDashboard.putBoolean("Found Line", findLine().lineFound);
         SmartDashboard.putNumber("Line Angle", findLine().lineAngle);
-        Trace.getInstance().addTrace(true, "LineFollower", new TracePair("LS0", returnSensorReadingBuffer[0]),
-            new TracePair("LS1", returnSensorReadingBuffer[1]), new TracePair("LS2", returnSensorReadingBuffer[2]),
-            new TracePair("LS3", returnSensorReadingBuffer[3]), new TracePair("LS4", returnSensorReadingBuffer[4]),
-            new TracePair("LS5", returnSensorReadingBuffer[5]), new TracePair("LS6", returnSensorReadingBuffer[6]),
-            new TracePair("LS7", returnSensorReadingBuffer[7]),
-            new TracePair("DistFromCenter", currentDistanceFromCenter),
-            new TracePair("LineAngle", findLine().lineAngle));
+        Trace.getInstance().addTrace(true, "LineFollower", new TracePair<>("LS0", returnSensorReadingBuffer[0]),
+            new TracePair<>("LS1", returnSensorReadingBuffer[1]), new TracePair<>("LS2", returnSensorReadingBuffer[2]),
+            new TracePair<>("LS3", returnSensorReadingBuffer[3]), new TracePair<>("LS4", returnSensorReadingBuffer[4]),
+            new TracePair<>("LS5", returnSensorReadingBuffer[5]), new TracePair<>("LS6", returnSensorReadingBuffer[6]),
+            new TracePair<>("LS7", returnSensorReadingBuffer[7]),
+            new TracePair<>("DistFromCenter", currentDistanceFromCenter),
+            new TracePair<>("LineAngle", findLine().lineAngle));
         Timer.delay(threadTime);
       }
     }

--- a/src/main/java/frc/robot/subsystems/drivetrain/RealDriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/RealDriveTrain.java
@@ -229,8 +229,8 @@ public class RealDriveTrain extends DriveTrain {
   }
 
   public void move(double forwardBackSpeed, double rotateAmount, boolean squaredInputs) {
-    Trace.getInstance().addTrace(true, "move", new TracePair("ForwardBack", forwardBackSpeed),
-        new TracePair("Rotate", rotateAmount));
+    Trace.getInstance().addTrace(false, "move", new TracePair<>("ForwardBack", forwardBackSpeed),
+        new TracePair<>("Rotate", rotateAmount));
     // logMeasurements("Left", driveTrainLeftMaster, forwardBackSpeed, false);
     // logMeasurements("Right", driveTrainRightMaster, -forwardBackSpeed, true);
     if (invertTurning) {
@@ -249,15 +249,10 @@ public class RealDriveTrain extends DriveTrain {
       System.out.println("TALON IS NULL!!! ");
     }
     double motorOutput = _talon.getMotorOutputPercent();
-    Trace.getInstance().addTrace(false, "VCMeasure" + side, new TracePair("Percent", (double) motorOutput * 100),
-        new TracePair("Speed", (double) _talon.getSelectedSensorVelocity(slotIdx)),
-        new TracePair("Error", (double) _talon.getClosedLoopError(slotIdx)),
-        new TracePair("Target", (double) _talon.getClosedLoopTarget(slotIdx)));
-//        new TracePair("Battery Voltage", (double) _talon.getBusVoltage()),
-//        new TracePair("Current Channel 0", (double) pdp.getCurrent(0)),
-//        new TracePair("Current Channel 1", (double) pdp.getCurrent(1)),
-//        new TracePair("Current Channel 2", (double) pdp.getCurrent(2)),
-//        new TracePair("Current Channel 3", (double) pdp.getCurrent(3)));
+    Trace.getInstance().addTrace(false, "VCMeasure" + side, new TracePair<>("Percent", (double) motorOutput * 100),
+        new TracePair<>("Speed", (double) _talon.getSelectedSensorVelocity(slotIdx)),
+        new TracePair<>("Error", (double) _talon.getClosedLoopError(slotIdx)),
+        new TracePair<>("Target", (double) _talon.getClosedLoopTarget(slotIdx)));
   }
 
   public void stop() {

--- a/src/main/java/frc/robot/telemetries/Trace.java
+++ b/src/main/java/frc/robot/telemetries/Trace.java
@@ -32,8 +32,8 @@ import frc.robot.Robot;
 // Trace.getInstance().addTrace(...) at the point where you want to trace some
 // interesting values. the addTrace signature is as follow:
 // addTrace(<filename for trace file, .csv will be appended>,
-// 			new TracePair(<name of this column>, <value to be written>),
-//  		new TracePair(...),
+// 			new TracePair<>(<name of this column>, <value to be written>),
+//  		new TracePair<>(...),
 //			<as many items as you want to log>);
 //
 // on the first call to this method with a unique filename, 
@@ -43,10 +43,10 @@ import frc.robot.Robot;
 // been encountered, the method will simply store the values passed in.
 // an example for tracing the navx:
 // Trace.getInstance().addTrace("NavxGyro", 
-// 		new TracePair("Raw Angle", m_navX.getAngle()),
-//		new TracePair("X Accel", (double) m_navX.getWorldLinearAccelX()),
-//		new TracePair("X Accel", (double) m_navX.getWorldLinearAccelY()),
-//		new TracePair("Z Accel", (double) m_navX.getWorldLinearAccelZ()));
+// 		new TracePair<>("Raw Angle", m_navX.getAngle()),
+//		new TracePair<>("X Accel", (double) m_navX.getWorldLinearAccelX()),
+//		new TracePair<>("X Accel", (double) m_navX.getWorldLinearAccelY()),
+//		new TracePair<>("Z Accel", (double) m_navX.getWorldLinearAccelZ()));
 //
 // on the first call a file NavxGyro will be created in the trace directory.
 // the header: Raw Angle, X Accel, Y Accel, Z Accel will be written to the file along
@@ -197,7 +197,7 @@ public class Trace {
     }
   }
 
-  public void addTrace(boolean enable, String fileName, TracePair... header) {
+  public <T> void addTrace(boolean enable, String fileName, TracePair<T>... header) {
     if (!enable) {
       return;
     }
@@ -208,7 +208,8 @@ public class Trace {
     addEntry(traceEntry, header);
   }
 
-  private synchronized TraceEntry getTraceEntry(String fileName, TracePair... header) {
+  @SafeVarargs
+  private synchronized <T> TraceEntry getTraceEntry(String fileName, TracePair<T>... header) {
     TraceEntry traceEntry = null;
     try {
       if (!m_traces.containsKey(fileName)) {
@@ -219,7 +220,7 @@ public class Trace {
         traceEntry = new TraceEntry(outputFile, header.length);
         m_traces.put(fileName, traceEntry);
         String line = new String("Time");
-        for (TracePair pair : header) {
+        for (TracePair<T> pair : header) {
           line += "," + pair.getColumnName();
         }
         outputFile.write(line);
@@ -235,7 +236,8 @@ public class Trace {
     return traceEntry;
   }
 
-  private void addEntry(TraceEntry traceEntry, TracePair... values) {
+  @SafeVarargs
+  private <T> void addEntry(TraceEntry traceEntry, TracePair<T>... values) {
     try {
       if (!Robot.getInstance().isEnabled()) {
         return;
@@ -254,7 +256,7 @@ public class Trace {
       }
       long correctedTime = System.currentTimeMillis() - m_startTime;
       String line = new String(String.valueOf(correctedTime));
-      for (TracePair entry : values) {
+      for (TracePair<T> entry : values) {
         line += "," + entry.getValue();
       }
       traceEntry.getFile().write(line);


### PR DESCRIPTION
…easily inferes what the template should be). there is still one ridiculous circular warning that i cannot remove. delete a bunch of commented out code. turn off tracing (by setting the first parameter to false) of the gyro and the move stick positions.